### PR TITLE
Fix: Use passlib for NTLM hash to support systems without MD4 in hashlib

### DIFF
--- a/httpping/main.py
+++ b/httpping/main.py
@@ -18,6 +18,8 @@ from spnego._ntlm_raw.messages import Challenge
 from spnego._spnego import unpack_token
 import spnego
 
+from passlib.hash import nthash as passlib_nthash
+
 session = Session()
 session.verify = False
 
@@ -29,28 +31,38 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 original_client = spnego.client
 
+
 def monkey_client(username: str, password: str, *args, **kwargs):
-    return original_client([NTLMHash(username, None, password)], password=None, *args, **kwargs)
+    return original_client(
+        [NTLMHash(username, None, password)], password=None, *args, **kwargs
+    )
+
 
 spnego.client = monkey_client
 
 
 def main() -> None:
     entrypoint = ArgumentParser()
-    entrypoint.add_argument('--threads', type=int, default=1, metavar='UINT')
-    entrypoint.add_argument('--user-agent', default='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6356.209 Safari/537.36', metavar='STRING')
-    group = entrypoint.add_argument_group('auth')
-    group.add_argument('-d', '--domain', default='')
-    group.add_argument('-u', '--username', default='')
+    entrypoint.add_argument("--threads", type=int, default=1, metavar="UINT")
+    entrypoint.add_argument(
+        "--user-agent",
+        default="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6356.209 Safari/537.36",
+        metavar="STRING",
+    )
+    group = entrypoint.add_argument_group("auth")
+    group.add_argument("-d", "--domain", default="")
+    group.add_argument("-u", "--username", default="")
     group = group.add_mutually_exclusive_group()
-    group.add_argument('-p', '--password', default='')
-    group.add_argument('-H', '--hash', default='')
-    entrypoint.add_argument('targets', nargs='*', metavar='URL')
+    group.add_argument("-p", "--password", default="")
+    group.add_argument("-H", "--hash", default="")
+    entrypoint.add_argument("targets", nargs="*", metavar="URL")
     opts = entrypoint.parse_args()
 
-    session.headers['User-Agent'] = opts.user_agent
+    session.headers["User-Agent"] = opts.user_agent
     with ThreadPoolExecutor(max_workers=opts.threads) as pool:
-        targets = opts.targets if opts.targets else (line.rstrip() for line in sys.stdin)
+        targets = (
+            opts.targets if opts.targets else (line.rstrip() for line in sys.stdin)
+        )
         for result in pool.map(ping, itertools.repeat(opts), targets):
             log(**result)
 
@@ -58,56 +70,86 @@ def main() -> None:
 def ping(opts: Namespace, target: str) -> dict[str, Any]:
     test1 = session.get(target)
     auth_methods = extract_auth_methods(test1)
-    username = f'{opts.domain}\\{opts.username}' if opts.domain else opts.username
-    if 'basic' in auth_methods and username:
+    username = f"{opts.domain}\\{opts.username}" if opts.domain else opts.username
+    if "basic" in auth_methods and username:
         auth = HTTPBasicAuth(username, opts.password)
-    elif 'ntlm' in auth_methods:
-        nthash = opts.hash if opts.hash else hashlib.new('md4', opts.password.encode('utf-16le')).hexdigest()
+    elif "ntlm" in auth_methods:
+        nthash = opts.hash if opts.hash else passlib_nthash.hash(opts.password)
         auth = HttpNtlmAuth(username, nthash, send_cbt=True)
     else:
-        return make_result(target, test1, authentication=auth_methods, channel_binding=None, ntlm_info=None)
+        return make_result(
+            target,
+            test1,
+            authentication=auth_methods,
+            channel_binding=None,
+            ntlm_info=None,
+        )
     test2 = session.get(target, auth=auth)
-    ntlm_info = extract_ntlm_info(test2.history[-1]) if isinstance(auth, HttpNtlmAuth) else None
+    ntlm_info = (
+        extract_ntlm_info(test2.history[-1]) if isinstance(auth, HttpNtlmAuth) else None
+    )
     if test2.status_code == 401 or not isinstance(auth, HttpNtlmAuth):
-        return make_result(target, test2, authentication=auth_methods, channel_binding=None, ntlm_info=ntlm_info)
+        return make_result(
+            target,
+            test2,
+            authentication=auth_methods,
+            channel_binding=None,
+            ntlm_info=ntlm_info,
+        )
     # close connection to force reauthentication
     session.close()
     # retest without channel binding
     auth.send_cbt = False
     test3 = session.get(target, auth=auth)
-    return make_result(target, test2, authentication=auth_methods, channel_binding=test3.status_code == 401, ntlm_info=ntlm_info)
+    return make_result(
+        target,
+        test2,
+        authentication=auth_methods,
+        channel_binding=test3.status_code == 401,
+        ntlm_info=ntlm_info,
+    )
 
 
 def extract_auth_methods(response: Response) -> list[str]:
-    header = response.headers.get('WWW-Authenticate', '')
+    header = response.headers.get("WWW-Authenticate", "")
     if not header:
         return []
-    return header.lower().split(', ')
+    return header.lower().split(", ")
 
 
 def extract_ntlm_info(response: Response) -> dict[str, str]:
-    header = response.headers.get('WWW-Authenticate', '')
-    if not header.startswith('NTLM '):
+    header = response.headers.get("WWW-Authenticate", "")
+    if not header.startswith("NTLM "):
         return {}
-    message = base64.b64decode(header.removeprefix('NTLM '))
+    message = base64.b64decode(header.removeprefix("NTLM "))
     token = unpack_token(message, unwrap=True)
     if not isinstance(token, Challenge):
         return {}
     result = {}
     if token.version:
-        result.update(name=token.target_name, version=f'{token.version.major}.{token.version.minor}.{token.version.build}')
+        result.update(
+            name=token.target_name,
+            version=f"{token.version.major}.{token.version.minor}.{token.version.build}",
+        )
     if token.target_info:
-        result.update({k.name: v for k, v in token.target_info.items() if k.name not in ('timestamp', 'eol')})
+        result.update(
+            {
+                k.name: v
+                for k, v in token.target_info.items()
+                if k.name not in ("timestamp", "eol")
+            }
+        )
     return result
 
 
-TITLE_PATTERN = re.compile(b'<title>([^<>]+)</title>', re.IGNORECASE)
+TITLE_PATTERN = re.compile(b"<title>([^<>]+)</title>", re.IGNORECASE)
+
 
 def extract_title(response: Response) -> str:
     match = TITLE_PATTERN.search(response.content)
     if not match:
-        return ''
-    return match.group(1).decode('utf-8', errors='surrogateescape')
+        return ""
+    return match.group(1).decode("utf-8", errors="surrogateescape")
 
 
 def make_result(target: str, response: Response, **kwargs: Any) -> dict[str, Any]:
@@ -115,8 +157,8 @@ def make_result(target: str, response: Response, **kwargs: Any) -> dict[str, Any
         url=target,
         status_code=response.status_code,
         reason=response.reason,
-        server=response.headers.get('Server', ''),
-        content_type=response.headers.get('Content-Type', '').lower().split(';')[0],
+        server=response.headers.get("Server", ""),
+        content_type=response.headers.get("Content-Type", "").lower().split(";")[0],
         headers={k.lower(): v for k, v in response.headers.items()},
         size=len(response.content),
         title=extract_title(response),
@@ -125,8 +167,8 @@ def make_result(target: str, response: Response, **kwargs: Any) -> dict[str, Any
 
 
 def log(**kwargs: Any) -> None:
-    print(json.dumps(kwargs, separators=(',', ':')))
+    print(json.dumps(kwargs, separators=(",", ":")))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/httpping/main.py
+++ b/httpping/main.py
@@ -31,38 +31,28 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 original_client = spnego.client
 
-
 def monkey_client(username: str, password: str, *args, **kwargs):
-    return original_client(
-        [NTLMHash(username, None, password)], password=None, *args, **kwargs
-    )
-
+    return original_client([NTLMHash(username, None, password)], password=None, *args, **kwargs)
 
 spnego.client = monkey_client
 
 
 def main() -> None:
     entrypoint = ArgumentParser()
-    entrypoint.add_argument("--threads", type=int, default=1, metavar="UINT")
-    entrypoint.add_argument(
-        "--user-agent",
-        default="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6356.209 Safari/537.36",
-        metavar="STRING",
-    )
-    group = entrypoint.add_argument_group("auth")
-    group.add_argument("-d", "--domain", default="")
-    group.add_argument("-u", "--username", default="")
+    entrypoint.add_argument('--threads', type=int, default=1, metavar='UINT')
+    entrypoint.add_argument('--user-agent', default='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6356.209 Safari/537.36', metavar='STRING')
+    group = entrypoint.add_argument_group('auth')
+    group.add_argument('-d', '--domain', default='')
+    group.add_argument('-u', '--username', default='')
     group = group.add_mutually_exclusive_group()
-    group.add_argument("-p", "--password", default="")
-    group.add_argument("-H", "--hash", default="")
-    entrypoint.add_argument("targets", nargs="*", metavar="URL")
+    group.add_argument('-p', '--password', default='')
+    group.add_argument('-H', '--hash', default='')
+    entrypoint.add_argument('targets', nargs='*', metavar='URL')
     opts = entrypoint.parse_args()
 
-    session.headers["User-Agent"] = opts.user_agent
+    session.headers['User-Agent'] = opts.user_agent
     with ThreadPoolExecutor(max_workers=opts.threads) as pool:
-        targets = (
-            opts.targets if opts.targets else (line.rstrip() for line in sys.stdin)
-        )
+        targets = opts.targets if opts.targets else (line.rstrip() for line in sys.stdin)
         for result in pool.map(ping, itertools.repeat(opts), targets):
             log(**result)
 
@@ -70,86 +60,56 @@ def main() -> None:
 def ping(opts: Namespace, target: str) -> dict[str, Any]:
     test1 = session.get(target)
     auth_methods = extract_auth_methods(test1)
-    username = f"{opts.domain}\\{opts.username}" if opts.domain else opts.username
-    if "basic" in auth_methods and username:
+    username = f'{opts.domain}\\{opts.username}' if opts.domain else opts.username
+    if 'basic' in auth_methods and username:
         auth = HTTPBasicAuth(username, opts.password)
-    elif "ntlm" in auth_methods:
+    elif 'ntlm' in auth_methods:
         nthash = opts.hash if opts.hash else passlib_nthash.hash(opts.password)
         auth = HttpNtlmAuth(username, nthash, send_cbt=True)
     else:
-        return make_result(
-            target,
-            test1,
-            authentication=auth_methods,
-            channel_binding=None,
-            ntlm_info=None,
-        )
+        return make_result(target, test1, authentication=auth_methods, channel_binding=None, ntlm_info=None)
     test2 = session.get(target, auth=auth)
-    ntlm_info = (
-        extract_ntlm_info(test2.history[-1]) if isinstance(auth, HttpNtlmAuth) else None
-    )
+    ntlm_info = extract_ntlm_info(test2.history[-1]) if isinstance(auth, HttpNtlmAuth) else None
     if test2.status_code == 401 or not isinstance(auth, HttpNtlmAuth):
-        return make_result(
-            target,
-            test2,
-            authentication=auth_methods,
-            channel_binding=None,
-            ntlm_info=ntlm_info,
-        )
+        return make_result(target, test2, authentication=auth_methods, channel_binding=None, ntlm_info=ntlm_info)
     # close connection to force reauthentication
     session.close()
     # retest without channel binding
     auth.send_cbt = False
     test3 = session.get(target, auth=auth)
-    return make_result(
-        target,
-        test2,
-        authentication=auth_methods,
-        channel_binding=test3.status_code == 401,
-        ntlm_info=ntlm_info,
-    )
+    return make_result(target, test2, authentication=auth_methods, channel_binding=test3.status_code == 401, ntlm_info=ntlm_info)
 
 
 def extract_auth_methods(response: Response) -> list[str]:
-    header = response.headers.get("WWW-Authenticate", "")
+    header = response.headers.get('WWW-Authenticate', '')
     if not header:
         return []
-    return header.lower().split(", ")
+    return header.lower().split(', ')
 
 
 def extract_ntlm_info(response: Response) -> dict[str, str]:
-    header = response.headers.get("WWW-Authenticate", "")
-    if not header.startswith("NTLM "):
+    header = response.headers.get('WWW-Authenticate', '')
+    if not header.startswith('NTLM '):
         return {}
-    message = base64.b64decode(header.removeprefix("NTLM "))
+    message = base64.b64decode(header.removeprefix('NTLM '))
     token = unpack_token(message, unwrap=True)
     if not isinstance(token, Challenge):
         return {}
     result = {}
     if token.version:
-        result.update(
-            name=token.target_name,
-            version=f"{token.version.major}.{token.version.minor}.{token.version.build}",
-        )
+        result.update(name=token.target_name, version=f'{token.version.major}.{token.version.minor}.{token.version.build}')
     if token.target_info:
-        result.update(
-            {
-                k.name: v
-                for k, v in token.target_info.items()
-                if k.name not in ("timestamp", "eol")
-            }
-        )
+        result.update({k.name: v for k, v in token.target_info.items() if k.name not in ('timestamp', 'eol')})
     return result
 
 
-TITLE_PATTERN = re.compile(b"<title>([^<>]+)</title>", re.IGNORECASE)
-
+TITLE_PATTERN = re.compile(b'<title>([^<>]+)</title>', re.IGNORECASE)
 
 def extract_title(response: Response) -> str:
     match = TITLE_PATTERN.search(response.content)
     if not match:
-        return ""
-    return match.group(1).decode("utf-8", errors="surrogateescape")
+        return ''
+    return match.group(1).decode('utf-8', errors='surrogateescape')
 
 
 def make_result(target: str, response: Response, **kwargs: Any) -> dict[str, Any]:
@@ -157,8 +117,8 @@ def make_result(target: str, response: Response, **kwargs: Any) -> dict[str, Any
         url=target,
         status_code=response.status_code,
         reason=response.reason,
-        server=response.headers.get("Server", ""),
-        content_type=response.headers.get("Content-Type", "").lower().split(";")[0],
+        server=response.headers.get('Server', ''),
+        content_type=response.headers.get('Content-Type', '').lower().split(';')[0],
         headers={k.lower(): v for k, v in response.headers.items()},
         size=len(response.content),
         title=extract_title(response),
@@ -167,8 +127,8 @@ def make_result(target: str, response: Response, **kwargs: Any) -> dict[str, Any
 
 
 def log(**kwargs: Any) -> None:
-    print(json.dumps(kwargs, separators=(",", ":")))
+    print(json.dumps(kwargs, separators=(',', ':')))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -197,43 +197,47 @@ files = [
 
 [[package]]
 name = "cryptography"
-version = "44.0.1"
+version = "44.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.7"
 groups = ["main"]
 files = [
-    {file = "cryptography-44.0.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf688f615c29bfe9dfc44312ca470989279f0e94bb9f631f85e3459af8efc009"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd7c7e2d71d908dc0f8d2027e1604102140d84b155e658c20e8ad1304317691f"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887143b9ff6bad2b7570da75a7fe8bbf5f65276365ac259a5d2d5147a73775f2"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:322eb03ecc62784536bc173f1483e76747aafeb69c8728df48537eb431cd1911"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:21377472ca4ada2906bc313168c9dc7b1d7ca417b63c1c3011d0c74b7de9ae69"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:df978682c1504fc93b3209de21aeabf2375cb1571d4e61907b3e7a2540e83026"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:eb3889330f2a4a148abead555399ec9a32b13b7c8ba969b72d8e500eb7ef84cd"},
-    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6a85a93d0642bd774460a86513c5d9d80b5c002ca9693e63f6e540f1815ed0"},
-    {file = "cryptography-44.0.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6f76fdd6fd048576a04c5210d53aa04ca34d2ed63336d4abd306d0cbe298fddf"},
-    {file = "cryptography-44.0.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6c8acf6f3d1f47acb2248ec3ea261171a671f3d9428e34ad0357148d492c7864"},
-    {file = "cryptography-44.0.1-cp37-abi3-win32.whl", hash = "sha256:24979e9f2040c953a94bf3c6782e67795a4c260734e5264dceea65c8f4bae64a"},
-    {file = "cryptography-44.0.1-cp37-abi3-win_amd64.whl", hash = "sha256:fd0ee90072861e276b0ff08bd627abec29e32a53b2be44e41dbcdf87cbee2b00"},
-    {file = "cryptography-44.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a2d8a7045e1ab9b9f803f0d9531ead85f90c5f2859e653b61497228b18452008"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8272f257cf1cbd3f2e120f14c68bff2b6bdfcc157fafdee84a1b795efd72862"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e8d181e90a777b63f3f0caa836844a1182f1f265687fac2115fcf245f5fbec3"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:436df4f203482f41aad60ed1813811ac4ab102765ecae7a2bbb1dbb66dcff5a7"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4f422e8c6a28cf8b7f883eb790695d6d45b0c385a2583073f3cec434cc705e1a"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:72198e2b5925155497a5a3e8c216c7fb3e64c16ccee11f0e7da272fa93b35c4c"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a46a89ad3e6176223b632056f321bc7de36b9f9b93b2cc1cccf935a3849dc62"},
-    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:53f23339864b617a3dfc2b0ac8d5c432625c80014c25caac9082314e9de56f41"},
-    {file = "cryptography-44.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:888fcc3fce0c888785a4876ca55f9f43787f4c5c1cc1e2e0da71ad481ff82c5b"},
-    {file = "cryptography-44.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:00918d859aa4e57db8299607086f793fa7813ae2ff5a4637e318a25ef82730f7"},
-    {file = "cryptography-44.0.1-cp39-abi3-win32.whl", hash = "sha256:9b336599e2cb77b1008cb2ac264b290803ec5e8e89d618a5e978ff5eb6f715d9"},
-    {file = "cryptography-44.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:e403f7f766ded778ecdb790da786b418a9f2394f36e8cc8b796cc056ab05f44f"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1f9a92144fa0c877117e9748c74501bea842f93d21ee00b0cf922846d9d0b183"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:610a83540765a8d8ce0f351ce42e26e53e1f774a6efb71eb1b41eb01d01c3d12"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:5fed5cd6102bb4eb843e3315d2bf25fede494509bddadb81e03a859c1bc17b83"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f4daefc971c2d1f82f03097dc6f216744a6cd2ac0f04c68fb935ea2ba2a0d420"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94f99f2b943b354a5b6307d7e8d19f5c423a794462bde2bf310c770ba052b1c4"},
-    {file = "cryptography-44.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d9c5b9f698a83c8bd71e0f4d3f9f839ef244798e5ffe96febfa9714717db7af7"},
-    {file = "cryptography-44.0.1.tar.gz", hash = "sha256:f51f5705ab27898afda1aaa430f34ad90dc117421057782022edf0600bec5f14"},
+    {file = "cryptography-44.0.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4973da6ca3db4405c54cd0b26d328be54c7747e89e284fcff166132eb7bccc9c"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a"},
+    {file = "cryptography-44.0.2-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308"},
+    {file = "cryptography-44.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1bc312dfb7a6e5d66082c87c34c8a62176e684b6fe3d90fcfe1568de675e6688"},
+    {file = "cryptography-44.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b721b8b4d948b218c88cb8c45a01793483821e709afe5f622861fc6182b20a7"},
+    {file = "cryptography-44.0.2-cp37-abi3-win32.whl", hash = "sha256:51e4de3af4ec3899d6d178a8c005226491c27c4ba84101bfb59c901e10ca9f79"},
+    {file = "cryptography-44.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:c505d61b6176aaf982c5717ce04e87da5abc9a36a5b39ac03905c4aafe8de7aa"},
+    {file = "cryptography-44.0.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e0ddd63e6bf1161800592c71ac794d3fb8001f2caebe0966e77c5234fa9efc3"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6210c05941994290f3f7f175a4a57dbbb2afd9273657614c506d5976db061181"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b042d2a275c8cee83a4b7ae30c45a15e6a4baa65a179a0ec2d78ebb90e4f6699"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d03806036b4f89e3b13b6218fefea8d5312e450935b1a2d55f0524e2ed7c59d9"},
+    {file = "cryptography-44.0.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23"},
+    {file = "cryptography-44.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922"},
+    {file = "cryptography-44.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4"},
+    {file = "cryptography-44.0.2-cp39-abi3-win32.whl", hash = "sha256:3dc62975e31617badc19a906481deacdeb80b4bb454394b4098e3f2525a488c5"},
+    {file = "cryptography-44.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:5f6f90b72d8ccadb9c6e311c775c8305381db88374c65fa1a68250aa8a9cb3a6"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:af4ff3e388f2fa7bff9f7f2b31b87d5651c45731d3e8cfa0944be43dff5cfbdb"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:0529b1d5a0105dd3731fa65680b45ce49da4d8115ea76e9da77a875396727b41"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:7ca25849404be2f8e4b3c59483d9d3c51298a22c1c61a0e84415104dacaf5562"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:268e4e9b177c76d569e8a145a6939eca9a5fec658c932348598818acf31ae9a5"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9eb9d22b0a5d8fd9925a7764a054dca914000607dff201a24c791ff5c799e1fa"},
+    {file = "cryptography-44.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2bf7bf75f7df9715f810d1b038870309342bff3069c5bd8c6b96128cb158668d"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:909c97ab43a9c0c0b0ada7a1281430e4e5ec0458e6d9244c0e821bbf152f061d"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:96e7a5e9d6e71f9f4fca8eebfd603f8e86c5225bb18eb621b2c1e50b290a9471"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d1b3031093a366ac767b3feb8bcddb596671b3aaff82d4050f984da0c248b615"},
+    {file = "cryptography-44.0.2-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:04abd71114848aa25edb28e225ab5f268096f44cf0127f3d36975bdf1bdf3390"},
+    {file = "cryptography-44.0.2.tar.gz", hash = "sha256:c63454aa261a0cf0c5b4718349629793e9e634993538db841165b3df74f37ec0"},
 ]
 
 [package.dependencies]
@@ -246,7 +250,7 @@ nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2) ; python_version >= \"3.8\""]
 pep8test = ["check-sdist ; python_version >= \"3.8\"", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==44.0.1)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==44.0.2)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -263,6 +267,24 @@ files = [
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+
+[[package]]
+name = "passlib"
+version = "1.7.4"
+description = "comprehensive password hashing framework supporting over 30 schemes"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1"},
+    {file = "passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04"},
+]
+
+[package.extras]
+argon2 = ["argon2-cffi (>=18.2.0)"]
+bcrypt = ["bcrypt (>=3.1.0)"]
+build-docs = ["cloud-sptheme (>=1.10.1)", "sphinx (>=1.6)", "sphinxcontrib-fulltoc (>=1.2.0)"]
+totp = ["cryptography"]
 
 [[package]]
 name = "pycparser"
@@ -404,4 +426,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "65da359ee002364530f69ea3afd9ca4efdc81a69ae28611632c0fff0b3964226"
+content-hash = "ff8a6dd59579c392e1ed3f40e513c4c2f3fb5abd3bb941794ec921f84e3083c5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "requests (>=2.32.3,<3.0.0)",
-    "requests-ntlm (>=1.3.0,<2.0.0)"
+    "requests-ntlm (>=1.3.0,<2.0.0)",
+    "passlib (>=1.7.4,<2.0.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
This PR addresses a runtime error that occurs when running http-ping with NTLM authentication (--password option without explicit --hash) on systems where the underlying cryptographic library (usually OpenSSL linked with Python's hashlib) does not support or has disabled the MD4 hash algorithm.

When the tool attempts to calculate the NTLM hash using hashlib.new('md4', ...), it fails with the following traceback:

```bash      
Traceback (most recent call last):
  File "/usr/lib/python3.13/hashlib.py", line 160, in __hash_new
    return _hashlib.new(name, data, **kwargs)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
_hashlib.UnsupportedDigestmodError: [digital envelope routines] unsupported

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  # [...] Omitted intermediate frames for brevity
  File "/home/user/Tools/github/http-ping/httpping/main.py", line 65, in ping
    nthash = opts.hash if opts.hash else hashlib.new('md4', opts.password.encode('utf-16le')).hexdigest()
                                         ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 166, in __hash_new
    return __get_builtin_constructor(name)(data)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type md4
```

This PR implements the following changes:

- Adds passlib as a dependency: The passlib library is added to the project's dependencies (updated in pyproject.toml under [tool.poetry.dependencies]).

- Uses passlib for NTLM Hashing: The code in httpping/main.py responsible for calculating the NTLM hash is modified to use passlib.hash.nthash.hash(password) instead of hashlib.new('md4', ...). passlib provides a pure-Python implementation of the NTLM hash calculation, bypassing the need for MD4 support in the system's hashlib.
